### PR TITLE
Fix 0.11.0-rc.1 

### DIFF
--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -292,7 +292,6 @@ paths:
           description: |
             3GPP network access identifier for the subscription
             being used by the device.
-          example: "4d596ac1-7822-4927-a3c5-d72e1f922c94@domain.com"
           schema:
             $ref: "#/components/schemas/NetworkAccessIdentifier"
 
@@ -735,5 +734,3 @@ components:
     headers:
      x-correlator:
       $ref: "#/components/headers/x-correlator"
-
-

--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -736,3 +736,4 @@ components:
      x-correlator:
       $ref: "#/components/headers/x-correlator"
 
+


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug

#### What this PR does / why we need it:

Fixes trailing whitespace issue
Removes example from networkAccessIdentifier

#### Which issue(s) this PR fixes:

Fixes the trailing whitespace and inapplicable example resulting from the PR #23 [commit](https://github.com/camaraproject/SimpleEdgeDiscovery/pull/23/commits/6bea72271ee009f5e3db760b1e915767ba6ceb9e)

Further commits cannot be made to update PRs on a protected branches, hence this PR is needed to update PR #23



#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
