### PR TITLE
Reusable linting workflows - test of customized configuration - DO NOT MERGE

### DIFF
--- a/.github/workflows/pr_validation_caller.yml
+++ b/.github/workflows/pr_validation_caller.yml
@@ -24,6 +24,6 @@ jobs:
     uses: camaraproject/tooling/.github/workflows/pr_validation.yml@main
     secrets: inherit
 # This workflow calls the reusable workflow from tooling repository
-# Tools configuration from the tooling repository branch indicated by `configurations` variable    
+# Tools configuration from the tooling repository branch indicated by `configurations` variable  
     with:
       configurations: gherkinlint-update

--- a/.github/workflows/pr_validation_caller.yml
+++ b/.github/workflows/pr_validation_caller.yml
@@ -25,5 +25,5 @@ jobs:
     secrets: inherit
 # This workflow calls the reusable workflow from tooling repository
 # Tools configuration from the tooling repository branch indicated by `configurations` variable    
-#    with:
-#      configurations: staging
+    with:
+      configurations: gherkinlint-update


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
`pr_validation_caller.yml` uses configuration from  [gherkinlint-update](https://github.com/camaraproject/tooling/tree/gherkinlint-update) branch of the tooling repository where the `.gherkin-lintrc` file was changed according to https://github.com/camaraproject/Commonalities/pull/472

#### Special notes for reviewers:

This way the customized configuration can be created for specific API or tested before merging it into main branch. 


