### PR TITLE
Fixed wrong version in API_Readiness_Checklist.md

### DIFF
--- a/documentation/API_documentation/simple-edge-discovery_API_Readiness_Checklist.md
+++ b/documentation/API_documentation/simple-edge-discovery_API_Readiness_Checklist.md
@@ -1,6 +1,6 @@
 # API Readiness Checklist
 
-Checklist for simple-edge-discovery v1.1.0-alpha.1
+Checklist for simple-edge-discovery v1.0.0
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Comments |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation



#### What this PR does / why we need it:
To fix a historic mistake from Fall 24: API Readiness Checklist incorrectly states version 1.1.0-alpha.1 and should be 1.0.0 (version of latest release). It will be further updated for Fall 25.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #104 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
