### PR TITLE
Removed IDENTIFIER_MISMATCH step from simple-edge-discovery.feature

### DIFF
--- a/code/Test_definitions/simple-edge-discovery.feature
+++ b/code/Test_definitions/simple-edge-discovery.feature
@@ -33,12 +33,6 @@ Feature: CAMARA Simple Edge Discovery API - Operation readClosestEdgeCloudZone
     When The identifier(s) provided are not supported by the implementation
     Then Response code is 422 UNSUPPORTED_IDENTIFIER
 
-  @simple_edge_discovery_5_error_device_identifiers_mismatch
-  Scenario: Error because provided device indentifiers are inconsistent
-    Given the API Client makes a GET request to the {path_resource}
-    When The provided device identifiers are not consistent
-    Then Response code is 422 IDENTIFIER_MISMATCH
-
   @simple_edge_discovery_6_error_missing_identifier
   Scenario: Error because no identifier was provided
     Given the API Client makes a GET request to the {path_resource}


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction



#### What this PR does / why we need it:

Removes the IDENTIFIER_MISMATCH step as it is no a longer supported error


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #106 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
