### PR TITLE
chore: migrate swagger editor links to CAMARA swagger-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ simple-edge-discovery v0.11.0-rc.1 is a new release candidate version with signi
 
 - API definition **with inline documentation**:
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimpleEdgeDiscovery/r1.1/code/API_definitions/simple-edge-discovery.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimpleEdgeDiscovery/r1.1/code/API_definitions/simple-edge-discovery.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/SimpleEdgeDiscovery/r1.1/code/API_definitions/simple-edge-discovery.yaml)
   - OpenAPI [YAML spec file](https://raw.githubusercontent.com/camaraproject/SimpleEdgeDiscovery/r1.1/code/API_definitions/simple-edge-discovery.yaml)
  
 ### Added


### PR DESCRIPTION
## CAMARA Project Admin Update

This pull request migrates swagger editor links to use the CAMARA project's dedicated swagger-ui instance for better reliability (original links to swagger.io were broken).

**Changes:**
- Replaced `https://editor.swagger.io/` with `https://camaraproject.github.io/swagger-ui/`
- Replaced `https://editor-next.swagger.io/` with `https://camaraproject.github.io/swagger-ui/`
- All API specification URLs remain unchanged - only the swagger editor host is updated

**Benefits:**
- Consistent CAMARA experience
- Centralized swagger-ui configuration
- Maintained compatibility with existing specification URLs

**Files modified:**  CHANGELOG.md
**Links updated:** 1

🔧 **Generated via project-admin workflow**  
    Triggered by hdamker
    
    ---
    *This is an automated administrative update.*