### PR TITLE
docs: added section on Additional Error Responses

### DIFF
--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -144,8 +144,8 @@ info:
     the API specification may not document some non-mandatory error statuses as
     indicated in `CAMARA API Design Guidelines`.
 
-    Please refer to [CAMARA_common.yaml]({link_to_release}/CAMARA_common.yaml) for
-    a complete list of error responses.
+    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated
+    to this API version for a complete list of error responses.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error
     response if it is explicitly documented in the API.


### PR DESCRIPTION
Now updated to latest Commonalities template per /camaraproject/Commonalities/pull/457

#### What type of PR is this?

Add one of the following kinds:
* documentation



#### What this PR does / why we need it:
Updated to latest template text per /camaraproject/Commonalities/pull/457



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #92 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
