### PR TITLE
fix:  error 400 reference from Generic401 to Generic400

### DIFF
--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -237,7 +237,7 @@ paths:
         "200":
           $ref: "#/components/responses/200Success"
         "400":
-          $ref: "#/components/responses/Generic401"
+          $ref: "#/components/responses/Generic400"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug


#### What this PR does / why we need it:
Corrects the reference for the `400` error from `Generic400` to `Generic401`



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #149 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
