### PR TITLE
Target r2.3 maintenance release (simple-edge-discovery 2.0.1)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -10,31 +10,31 @@ repository:
   # Options: independent (default) | meta-release
   release_track: meta-release
   # Meta-release participation (update for next cycle when planning)
-  meta_release: Sync26
+  meta_release: Fall25
 
   # Target CAMARA release tag.
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r3.1
+  target_release_tag: r2.3
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: maintenance-release
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
-  identity_consent_management_release: r4.2
+  commonalities_release: r3.4
+  identity_consent_management_release: r3.3
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: simple-edge-discovery
-    target_api_version: 2.1.0
-    target_api_status: rc
+    target_api_version: 2.0.1
+    target_api_status: public
     main_contacts:
       - Kevsy
       - JoseMConde


### PR DESCRIPTION
#### What type of PR is this?

* repository management

#### What this PR does / why we need it:

Retargets `release-plan.yaml` to prepare the r2.3 maintenance release
that patches r2.2 (Fall25) with the error-400-reference fix landing in
#150.

Changes:

- `meta_release: Sync26` → `Fall25`
- `target_release_tag: r3.1` → `r2.3`
- `target_release_type: pre-release-rc` → `maintenance-release`
- `target_api_version: 2.1.0` → `2.0.1`
- `target_api_status: rc` → `public`
- `commonalities_release: r4.2` → `r3.4`
- `identity_consent_management_release: r4.2` → `r3.3`

Once r2.3 is published, a follow-up PR reverts these fields back to the
Sync26 plan (r3.1 / 2.1.0 / rc / Commonalities r4.2 / ICM r4.2).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

- Both this PR and #150 (the schema-ref fix) must be merged before
  `/create-snapshot` is fired on the Release Issue — merge order
  between the two does not matter.
- Triggers the Release Issue lifecycle via the release-automation caller
  installed by #151.
- Caller is pinned to `@validation-framework` (not `@v1-rc`) so the
  dual-mode CHANGELOG behaviour applies: r2.3 entry will land in flat
  `CHANGELOG.md` (no new `CHANGELOG/CHANGELOG-r2.md` created).

#### Changelog input

```
 release-note

```

#### Additional documentation 

```
docs

```