### PR TITLE
fix: add explicit type: object to DeviceResponseBody (S-016)

### DIFF
--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -432,6 +432,7 @@ components:
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
     DeviceResponseBody:
+      type: object
       description: |
         The optional device identifier to include in the response
       properties:


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Adds the missing `type: object` to the `DeviceResponseBody` schema in
`simple-edge-discovery.yaml`. Surfaced by CAMARA validation rule S-016
(`camara-schema-must-have-type`) while preparing the r2.3 maintenance
release.

The schema declares `properties` but no explicit type; this is a
Commonalities requirement — every schema should declare its type.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Will be required by 4.x validation, not strictly needed for r2.3

#### Changelog input

```
 release-note

```

#### Additional documentation

```
docs

```