### PR TITLE
fix: minor typo in AuthZ/AuthN text in template

### DIFF
--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -131,7 +131,7 @@ info:
     for the released version of the profile.
 
     The specific authorization flows to be used will be agreed upon during the
-    onboarding process, happening between the API consumer and API provider,
+    onboarding process, happening between the API consumer and the API provider,
     taking into account the declared purpose for accessing the API, whilst also
     being subject to the prevailing legal framework dictated by local legislation.
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

Adds 'the' before 'API provider' to avoid drift from canonical template


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #180 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
