### PR TITLE
fix: corrected the `$ref`s to `x-correlator`

### DIFF
--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -220,6 +220,7 @@ paths:
       operationId: readClosestEdgeCloudZone
       parameters:
         - in: header
+          description: Correlation id for the different services
           name: x-correlator
           schema:
             $ref: "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
@@ -273,9 +274,10 @@ components:
 
   headers:
     x-correlator:
+      description: Correlation id for the different services
       schema:
         $ref: "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
-        
+
   schemas:
     EdgeCloudZone:
       type: object

--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -222,7 +222,7 @@ paths:
         - in: header
           name: x-correlator
           schema:
-            $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+            $ref: "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
       requestBody:
         description: Parameters to create a new session
         required: true
@@ -274,7 +274,7 @@ components:
   headers:
     x-correlator:
       schema:
-        $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+        $ref: "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
         
   schemas:
     EdgeCloudZone:
@@ -343,7 +343,7 @@ components:
       description: 200 OK
       headers:
         x-correlator:
-          $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
       content:
         application/json:
           schema:

--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -221,8 +221,6 @@ paths:
       parameters:
         - in: header
           name: x-correlator
-          description: Correlation id for the different services
-          required: false
           schema:
             $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:
@@ -275,10 +273,9 @@ components:
 
   headers:
     x-correlator:
-      description: Correlation id for the different services
-      required: false
       schema:
         $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+        
   schemas:
     EdgeCloudZone:
       type: object
@@ -346,7 +343,7 @@ components:
       description: 200 OK
       headers:
         x-correlator:
-          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       content:
         application/json:
           schema:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

The previous `$ref`s pointed to the `parameter` and `header` instances of `x-correlator`, not the `schema/XCorrelator` object. This was causing invalid fields to appear once the `$ref`s had been imported, resulting in new validation errors.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
