### PR TITLE
fix: align x-correlator references with Commonalities

### DIFF
--- a/code/API_definitions/simple-edge-discovery.yaml
+++ b/code/API_definitions/simple-edge-discovery.yaml
@@ -219,12 +219,7 @@ paths:
             - simple-edge-discovery:read
       operationId: readClosestEdgeCloudZone
       parameters:
-        - in: header
-          name: x-correlator
-          description: Correlation id for the different services
-          required: false
-          schema:
-            $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:
         description: Parameters to create a new session
         required: true
@@ -273,12 +268,6 @@ components:
     openId:
       $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
 
-  headers:
-    x-correlator:
-      description: Correlation id for the different services
-      required: false
-      schema:
-        $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
   schemas:
     EdgeCloudZone:
       type: object


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Use the Commonalities `x-correlator` Parameter Object at the operation parameter site and the Commonalities `x-correlator` Header Object at the response header site.

This removes the local `components.headers.x-correlator` definition, which duplicated Commonalities and referenced the wrong object kind under `schema`.

#### Which issue(s) this PR fixes:

Fixes #183 

#### Special notes for reviewers:

This supersedes #184. It starts from upstream `main` and keeps `x-correlator` references aligned by OpenAPI object kind: Parameter Object for operation parameters and Header Object for response headers.

You can see and check the resulting bundled API always by downloading the "[validation-bundled-specs](https://github.com/camaraproject/SimpleEdgeDiscovery/actions/runs/28698251559/artifacts/8079301150)" artifact from the validation run.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation 

This section can be blank.

```
docs
```
